### PR TITLE
Add option to open analysis link in the default browser

### DIFF
--- a/sandbox_cli/cli/scanner/__init__.py
+++ b/sandbox_cli/cli/scanner/__init__.py
@@ -110,6 +110,14 @@ async def re_scan(
             group="Download options",
         ),
     ] = False,
+    open_browser: Annotated[
+        bool,
+        Parameter(
+            name=["--open-browser", "-ob"],
+            help="Open analysis link in the default browser",
+            negative="",
+        ),
+    ] = False,
 ) -> None:
     """
     Send traces to re-scan.
@@ -137,6 +145,7 @@ async def re_scan(
         is_local=is_local,
         unpack=unpack,
         debug=debug,
+        open_browser=open_browser,
     )
 
 
@@ -312,6 +321,14 @@ async def scan(
             negative="",
         ),
     ] = False,
+    open_browser: Annotated[
+        bool,
+        Parameter(
+            name=["--open-browser", "-ob"],
+            help="Open analysis link in the default browser",
+            negative="",
+        ),
+    ] = False,
 ) -> None:
     """
     Send files to scan with the sandbox.
@@ -374,6 +391,7 @@ async def scan(
         crashdumps=crashdumps,
         procdumps=procdumps,
         decompress=decompress,
+        open_browser=open_browser,
     )
 
 
@@ -630,6 +648,14 @@ async def scan_new(
             negative="",
         ),
     ] = False,
+    open_browser: Annotated[
+        bool,
+        Parameter(
+            name=["--open-browser", "-ob"],
+            help="Open analysis link in the default browser",
+            negative="",
+        ),
+    ] = False,
 ) -> None:
     """
     Send files to scan with the sandbox (advanced scan).
@@ -698,4 +724,5 @@ async def scan_new(
         crashdumps=crashdumps,
         procdumps=procdumps,
         decompress=decompress,
+        open_browser=open_browser,
     )

--- a/sandbox_cli/utils/scanner/__init__.py
+++ b/sandbox_cli/utils/scanner/__init__.py
@@ -1,3 +1,4 @@
+import webbrowser
 import asyncio
 import sys
 from collections.abc import Coroutine
@@ -56,6 +57,11 @@ def format_link(
         return "Unknown"
 
     return f"https://{key.host}/tasks/{short_report.scan_id}"
+
+
+def open_link(link: str):
+    if not webbrowser.open(link):
+        console.error(f"Can't open link in default browser.")
 
 
 async def _get_compiled_rules(rules_dir: Path | None, is_local: bool) -> bytes | None:
@@ -188,6 +194,7 @@ async def scan_internal(
     crashdumps: bool,
     procdumps: bool,
     decompress: bool,
+    open_browser: bool,
 ) -> None:
     key = get_key_by_name(key_name)
     sandbox_sem = asyncio.Semaphore(value=key.max_workers)
@@ -222,6 +229,10 @@ async def scan_internal(
             console.info(
                 rf"{idx} [magenta]\[{sandbox_options.sandbox.image_id}][/magenta] Waiting [yellow]{file_path.name}[/]: {format_link(scan_result, key=key)}"
             )
+
+            if open_browser:
+                open_link(format_link(scan_result, key=key))
+
             awaited_report = await sandbox.wait_for_report(scan_result, wait_time)
             if not awaited_report:
                 console.error(f"{idx} Scan [yellow]{file_path.name}[/] failed: {scan_result=}")

--- a/sandbox_cli/utils/scanner/advanced.py
+++ b/sandbox_cli/utils/scanner/advanced.py
@@ -18,7 +18,7 @@ from sandbox_cli.internal.helpers import get_key_by_name
 from sandbox_cli.utils.compiler import compile_rules_internal
 from sandbox_cli.utils.downloader import download
 from sandbox_cli.utils.merge_dll_hooks import merge_dll_hooks
-from sandbox_cli.utils.scanner import format_link
+from sandbox_cli.utils.scanner import format_link, open_link
 from sandbox_cli.utils.unpack import Unpack
 
 DELIMETER = "\n"
@@ -200,6 +200,7 @@ async def scan_internal_advanced(
     crashdumps: bool,
     procdumps: bool,
     decompress: bool,
+    open_browser: bool,
 ) -> None:
     key = get_key_by_name(key_name)
     sandbox_sem = asyncio.Semaphore(value=key.max_workers)
@@ -258,6 +259,9 @@ async def scan_internal_advanced(
 
             formatted_link = f"[medium_purple]{format_link(scan_result, key=key)}[/]"
             final_output = f"{image_string} • [yellow]{file_path.name}[/] • {formatted_link}"
+
+            if open_browser:
+                open_link(format_link(scan_result, key=key))
 
             progress.update(
                 task_id=task_id,

--- a/sandbox_cli/utils/scanner/rescan.py
+++ b/sandbox_cli/utils/scanner/rescan.py
@@ -21,7 +21,7 @@ from sandbox_cli.internal.config import settings
 from sandbox_cli.internal.helpers import get_key_by_name
 from sandbox_cli.utils.compiler import compile_rules_internal
 from sandbox_cli.utils.downloader import download
-from sandbox_cli.utils.scanner import format_link
+from sandbox_cli.utils.scanner import format_link, open_link
 from sandbox_cli.utils.unpack import Unpack
 
 
@@ -92,6 +92,7 @@ async def rescan_internal(
     is_local: bool,
     unpack: bool,
     debug: bool,
+    open_browser: bool,
 ) -> None:
     key = get_key_by_name(key_name)
     sandbox_sem = asyncio.Semaphore(value=key.max_workers)
@@ -147,6 +148,9 @@ async def rescan_internal(
 
             formatted_link = f"[medium_purple]{format_link(rescan_result, key=key)}[/]"
             final_output = f"[yellow]{trace.name}[/] • {formatted_link}"
+
+            if open_browser:
+                open_link(format_link(rescan_result, key=key))
 
             progress.update(
                 task_id=task_id,


### PR DESCRIPTION
Add option to open analysis link in the default browser by specifying flag --open-browser or -ob.