### PR TITLE
Save scan arguments and add command to open scan in the default browser for scan results

### DIFF
--- a/sandbox_cli/cli/__init__.py
+++ b/sandbox_cli/cli/__init__.py
@@ -4,7 +4,7 @@ Register all commands here
 
 from cyclopts import App
 
-from sandbox_cli.cli.reporter import generate_report
+from sandbox_cli.cli.reporter import generate_report, open_browser
 from sandbox_cli.cli.unpack import unpack_logs
 from sandbox_cli.console import console
 from sandbox_cli.internal.config import configpath, settings
@@ -32,6 +32,7 @@ app = App(
 
 app.command(name=["conv", "unpack"])(unpack_logs)
 app.command(name="report")(generate_report)
+app.command(name="browser")(open_browser)
 
 if len(settings.sandbox_keys) > 0:
     from sandbox_cli.cli.downloader import download_command, download_email

--- a/sandbox_cli/internal/helpers.py
+++ b/sandbox_cli/internal/helpers.py
@@ -1,10 +1,12 @@
 import sys
+from pathlib import Path
 from typing import Any
 
 from ptsandbox import SandboxKey
 
 from sandbox_cli.console import console
 from sandbox_cli.internal.config import settings
+from sandbox_cli.models.sandbox_arguments import SandboxArguments
 
 
 def get_key_by_name(key_name: str) -> SandboxKey:
@@ -30,3 +32,8 @@ def validate_key(_: Any, value: Any) -> None:
             f'Key "{value}" doesn\'t exists in config. Available keys: "{'","'.join(x.name for x in settings.sandbox_keys)}"'
         )
         sys.exit(1)
+
+
+def save_scan_arguments(out_dir: Path, scan_args: SandboxArguments):
+    scan_config_path = out_dir / "scan_config.json"
+    scan_config_path.write_text(scan_args.model_dump_json(exclude="debug_options", indent=4), encoding="utf-8")

--- a/sandbox_cli/models/sandbox_arguments.py
+++ b/sandbox_cli/models/sandbox_arguments.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+from ptsandbox.models.api import SandboxOptions, SandboxOptionsAdvanced
+from pydantic import BaseModel, Field
+
+
+class ScanType(str, Enum):
+    SCAN = "scan"
+    RE_SCAN = "re-scan"
+    SCAN_NEW = "scan-new"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def __repr__(self) -> str:
+        return str(self.value)
+
+
+class SandboxArguments(BaseModel):
+    type: ScanType
+    sandbox_key_name: str
+    sandbox_options: SandboxOptions | SandboxOptionsAdvanced

--- a/sandbox_cli/utils/scanner/__init__.py
+++ b/sandbox_cli/utils/scanner/__init__.py
@@ -15,8 +15,9 @@ from ptsandbox.models import (
 )
 
 from sandbox_cli.console import console
+from sandbox_cli.models.sandbox_arguments import SandboxArguments, ScanType
 from sandbox_cli.internal.config import VMImage, settings
-from sandbox_cli.internal.helpers import get_key_by_name
+from sandbox_cli.internal.helpers import get_key_by_name, save_scan_arguments
 from sandbox_cli.utils.compiler import compile_rules_internal
 from sandbox_cli.utils.downloader import download
 from sandbox_cli.utils.merge_dll_hooks import merge_dll_hooks
@@ -274,6 +275,8 @@ async def scan_internal(
         out_dir: Path,
         idx: str,
     ) -> None:
+        sandbox_arguments = SandboxArguments(type=ScanType.SCAN, sandbox_key_name=key.name, sandbox_options=sandbox_options.sandbox)
+        save_scan_arguments(out_dir, sandbox_arguments)
         # try:
         await process_file(sandbox_options, file_path, out_dir, idx)
         # except Exception as ex:

--- a/sandbox_cli/utils/scanner/advanced.py
+++ b/sandbox_cli/utils/scanner/advanced.py
@@ -13,8 +13,9 @@ from rich.markup import escape
 from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn, TimeElapsedColumn
 
 from sandbox_cli.console import console
+from sandbox_cli.models.sandbox_arguments import SandboxArguments, ScanType
 from sandbox_cli.internal.config import VMImage, settings
-from sandbox_cli.internal.helpers import get_key_by_name
+from sandbox_cli.internal.helpers import get_key_by_name, save_scan_arguments
 from sandbox_cli.utils.compiler import compile_rules_internal
 from sandbox_cli.utils.downloader import download
 from sandbox_cli.utils.merge_dll_hooks import merge_dll_hooks
@@ -317,6 +318,8 @@ async def scan_internal_advanced(
         out_dir: Path,
         idx: str,
     ) -> None:
+        sandbox_arguments = SandboxArguments(type=ScanType.SCAN_NEW, sandbox_key_name=key.name, sandbox_options=sandbox_options)
+        save_scan_arguments(out_dir, sandbox_arguments)
         # try:
         await process_file(sandbox_options, file_path, out_dir, idx)
         # except Exception as ex:

--- a/sandbox_cli/utils/scanner/rescan.py
+++ b/sandbox_cli/utils/scanner/rescan.py
@@ -18,7 +18,8 @@ from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn, TimeElaps
 
 from sandbox_cli.console import console
 from sandbox_cli.internal.config import settings
-from sandbox_cli.internal.helpers import get_key_by_name
+from sandbox_cli.internal.helpers import get_key_by_name, save_scan_arguments
+from sandbox_cli.models.sandbox_arguments import SandboxArguments, ScanType
 from sandbox_cli.utils.compiler import compile_rules_internal
 from sandbox_cli.utils.downloader import download
 from sandbox_cli.utils.scanner import format_link, open_link
@@ -241,10 +242,12 @@ async def rescan_internal(
     tasks: list[Coroutine[Any, Any, None]] = []
     with progress:
         sandbox, sandbox_options = await _prepare_rescan_options(progress, rules_dir, key, is_local)
+        sandbox_arguments = SandboxArguments(type=ScanType.RE_SCAN, sandbox_key_name=key.name, sandbox_options=sandbox_options.sandbox)
 
         if len(traces) == 1:
             local_out_dir = out_dir / "rescan"
             local_out_dir.mkdir(parents=True, exist_ok=True)
+            save_scan_arguments(local_out_dir, sandbox_arguments)
             tasks.append(wrapper(traces[0], local_out_dir, "1/1"))
         else:
             for i, trace in enumerate(traces):
@@ -255,6 +258,7 @@ async def rescan_internal(
                     local_out_dir = out_dir / trace.stem
 
                 local_out_dir.mkdir(parents=True, exist_ok=True)
+                save_scan_arguments(local_out_dir, sandbox_arguments)
                 idx = f"{i + 1}/{len(traces)}"
                 tasks.append(wrapper(trace, local_out_dir, idx))
 


### PR DESCRIPTION
Adds file `scan_config.json` to the folder with scan results for later use in report generation. Adds command `browser /path` to extract scan link from results and open it in the default browser.