### PR TITLE
Add option to specify custom browser in config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,11 +50,32 @@ Default: `["infected"]`
 | login    | The user's login on the server    | `None`  |
 | password | The user's password on the server | `None`  |
 
+#### `browser`
+
+Here you can specify custom browser to use for opening the analysis links.
+
+| Option   | Description                       | Default |
+| -------- | --------------------------------- | ------- |
+| path     | Path to custom browser            | `None`  |
+| args     | Args to start the browser with    | `None`  |
+
+!!! note "Note"
+
+    Every argument must be in separate string.
+
 ## Full configuration
 
 ```toml title="Config example"
 # passwords that will be sent to the sandbox for unpacking archives
 passwords = ["infected"]
+
+# Use this section only if you don't want to use your default browser
+# or it works incorrectly
+# [browser]
+# path to your browser
+# path = "C:\\Program Files\\Mozilla Firefox\\firefox.exe"
+# args to run your browser with
+# args = ["-new-tab"]
 
 # Specify available sandboxes
 # Keep in mind that first sandbox is used by default

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -60,6 +60,22 @@ in {
             default = null;
           };
 
+          browser = mkOption {
+            type = nullOrSubmodule {
+              options = {
+                path = mkOption {
+                  type = types.str;
+                };
+
+                args = mkOption {
+                  type = types.str;
+                };
+              };
+            };
+
+            default = null;
+          };
+
           rules-path = mkOption {
             type = types.nullOr (types.str);
             default = null;

--- a/sandbox_cli/internal/config.py
+++ b/sandbox_cli/internal/config.py
@@ -84,6 +84,10 @@ class Settings(BaseModel):
                 description=self.description,
             )
 
+    class Browser(BaseModel):
+        path: Path
+        args: list[str]
+
     # default settings (not changable)
     linux_images: set[VMImage] = {
         VMImage.ALTWORKSTATION_X64,
@@ -119,10 +123,13 @@ class Settings(BaseModel):
     docker: Docker = Docker()
     sandbox: list[Sandbox] = []
     rules_path: Path | None = Field(default=None, alias="rules-path")
+    browser: Browser | None = Field(default=None)
 
     def model_post_init(self, __context: Any) -> None:
         self.sandbox_keys = [x.sandbox_key for x in self.sandbox]
         self.rules_path = Path(self.rules_path) if self.rules_path else None
+        if self.browser:
+            self.browser.args.append("%s")
 
 
 def load_config(path: Path) -> Settings:

--- a/sandbox_cli/internal/helpers.py
+++ b/sandbox_cli/internal/helpers.py
@@ -78,5 +78,11 @@ def save_scan_arguments(out_dir: Path, scan_args: SandboxArguments) -> None:
 
 
 def open_link(link: str) -> None:
+    if settings.browser != None:
+        webbrowser.register("new_default_browser", None, webbrowser.GenericBrowser([settings.browser.path, *settings.browser.args]), preferred=True)
+        if not webbrowser.open(link):
+            console.error("Can't open link in the specified browser. Please check browser path and args.")
+        return
+    
     if not webbrowser.open_new_tab(link):
-        console.error("Can't open link in default browser.")
+        console.error("Can't open link in the default browser. Try adding path and args for your browser to the config file.")


### PR DESCRIPTION
Default python module `webbrowser` doesn't work correctly by default in some systems (e.g. MacOS). This PR adds option to config file to specify custom browser to use for opening links.