### PR TITLE
feat: remove "safe" suffix from the analysis filename

### DIFF
--- a/sandbox_cli/cli/scanner/__init__.py
+++ b/sandbox_cli/cli/scanner/__init__.py
@@ -707,6 +707,14 @@ async def scan_new(
             negative="",
         ),
     ] = False,
+    preserve_filename: Annotated[
+        bool,
+        Parameter(
+            name=["--preserve-filename", "-pf"],
+            help="Do not change filename for analysis.  \nWhen set to false (default behaviour): local/path/to/malware.exe[_~] -> sandbox/guest/os/malware.exe  \nWhen set to true name will remain unchanged.",
+            negative="",
+        ),
+    ] = False,
 ) -> None:
     """
     Send files to scan with the sandbox (advanced scan).
@@ -780,5 +788,6 @@ async def scan_new(
         procdumps=procdumps,
         decompress=decompress,
         open_browser=open_browser,
+        preserve_filename=preserve_filename,
         outbound_connections=outbound_connections,
     )

--- a/sandbox_cli/utils/scanner/advanced.py
+++ b/sandbox_cli/utils/scanner/advanced.py
@@ -39,6 +39,7 @@ from sandbox_cli.utils.merge_dll_hooks import merge_dll_hooks
 from sandbox_cli.utils.unpack import Unpack
 
 DELIMETER = "\n"
+SAFE_SUFFIXES = "_~"
 
 
 async def _get_compiled_rules(progress: Progress, rules_dir: Path | None, is_local: bool) -> bytes | None:
@@ -250,6 +251,7 @@ async def scan_internal_advanced(
     procdumps: bool,
     decompress: bool,
     open_browser: bool,
+    preserve_filename: bool,
     outbound_connections: list[str] | None,
 ) -> None:
     key = get_key_by_name(key_name)
@@ -291,9 +293,13 @@ async def scan_internal_advanced(
                 wait_time = wait_timeout
 
             try:
+                guest_filename = file_path.name
+                if not preserve_filename:
+                    guest_filename = guest_filename.rstrip(SAFE_SUFFIXES)
+
                 scan_result = await sandbox.create_advanced_scan(
                     file_path,
-                    file_name=fake_name or file_path.name,
+                    file_name=fake_name or guest_filename,
                     extra_files=extra_files,
                     async_result=True,
                     priority=priority,


### PR DESCRIPTION
Remove `[_~]` suffixes from files sent to analysis by default.  
Add option to preserve original filename.